### PR TITLE
Update VanderBot to v1.8

### DIFF
--- a/vanderbot/README.md
+++ b/vanderbot/README.md
@@ -29,7 +29,7 @@ Another utility, [count_entities.py](../json_schema/count_entities.py), can be u
 
 Script location: <https://github.com/HeardLibrary/linked-data/blob/master/vanderbot/vanderbot.py>
 
-Current version: v1.7.1
+Current version: v1.8
 
 Written by Steve Baskauf 2020-21.
 
@@ -62,6 +62,7 @@ Username and password are created on the `Bot passwords` page, accessed from `Sp
 | --credentials | -C | name of the credentials file | "wikibase_credentials.txt" |
 | --path | -P | credentials directory: "home", "working", or path with trailing "/" | "home" |
 | --update | -U | "allow" or "suppress" automatic updates to labels and descriptions | "suppress" |
+| --apisleep | -A | number of seconds to delay between edits (see notes on rate limits below) | 1.25 |
 | --endpoint | -E | a Wikibase SPARQL endpoint URL | "https://query.wikidata.org/sparql" |
 | --version | -V | no values; displays current version information |  |
 | --help | -H | no values; displays link to this page |  |
@@ -142,11 +143,11 @@ for 100 BCE. The dateTime strings MUST end in `T00:00:00Z` regardless of the pre
 
 # Rate limits
 
-Based on information acquired in 2020, bot password users who don't have a "[bot flag](https://www.wikidata.org/wiki/Wikidata:Bots)" are limited to 50 edits per minute. Editing at a faster rate will get you temporarily blocked from writing to the API. VanderBot has a [hard-coded delay](https://github.com/HeardLibrary/linked-data/blob/master/vanderbot/vanderbot.py#L215) to prevent it from writing faster than that rate. 
+Based on information acquired in 2020, bot password users who don't have a "[bot flag](https://www.wikidata.org/wiki/Wikidata:Bots)" are limited to 50 edits per minute. Editing at a faster rate will get you temporarily blocked from writing to the API. VanderBot has a [hard-coded limit](https://github.com/HeardLibrary/linked-data/blob/master/vanderbot/vanderbot.py#L219:L235) to prevent it from writing faster than that rate. 
 
-If you are a "newbie" (new user), you are subject to a slower rate limit: 8 edits per minute. A newbie is defined as a user whose account is less than four days old and who has done fewer than 50 edits. If you fall into the newbie category, you probably should do at least 50 manual edits to become familiar with the Wikidata data model and terminology anyway. However, if you don't want to wait, you should change the value of `api_sleep` from 1.25 to 8 in line 221. Once you are no longer a newbie, you can change it back to the higher rate.
+If you are a "newbie" (new user), you are subject to a slower rate limit: 8 edits per minute. A newbie is defined as a user whose account is less than four days old and who has done fewer than 50 edits. If you fall into the newbie category, you probably should do at least 50 manual edits to become familiar with the Wikidata data model and terminology anyway. However, if you don't want to wait, you should use an `--apisleep` or `-A` option with a value of `8` to set the delay to 8 seconds between writes. Once you are no longer a newbie, you can change it back to the higher rate by omitting this option.
 
 For more detail on rate limit settings, see [this page](https://www.mediawiki.org/wiki/Manual:$wgRateLimits) and the [configuration file](https://noc.wikimedia.org/conf/InitialiseSettings.php.txt) used by Wikidata.
 
 ----
-Revised 2021-08-04
+Revised 2021-08-15

--- a/vanderbot/vanderbot.py
+++ b/vanderbot/vanderbot.py
@@ -97,7 +97,7 @@ created = '2021-08-17'
 # Version 1.8 change notes (2021-08-17):
 # - enable --apisleep option to limit API write rate for newbies
 # - add error trapping for errors not allowed by API
-# - add special handling for commons media when P18 is used
+# - add special handling for Commons media when P18 is used
 
 import json
 import requests

--- a/vanderbot/vanderbot.py
+++ b/vanderbot/vanderbot.py
@@ -95,8 +95,8 @@ created = '2021-08-15'
 # add more complete error trapping for dates
 # -----------------------------------------
 # Version 1.8 change notes (2021-08-15):
-# - enable --version option.
-# 
+# - enable --apisleep option to limit API write rate for newbies
+# - add error trapping for errors not allowed by API
 
 import json
 import requests

--- a/vanderbot/vanderbot.py
+++ b/vanderbot/vanderbot.py
@@ -210,19 +210,30 @@ if credentials_path_string == 'home': # credential file is in home directory
     credentials_path = home + '/' + credentials_filename
 elif credentials_path_string == 'working': # credential file is in current working directory
     credentials_path = credentials_filename
+# Note: as of 2021 script will not run from Google Colab due to IP blocking. So this option isn't useful
 elif credentials_path_string == 'gdrive': # credential file is in the root of the Google Drive
     credentials_path = google_drive_root + credentials_filename
 else:  # credential file is in a directory whose path was specified by the credential_path_string
     credentials_path = credentials_path_string + credentials_filename
 
-
 # The limit for bots without a bot flag seems to be 50 writes per minute. That's 1.2 s between writes.
-# To be safe and avoid getting blocked, use 1.25 s as the api_sleep value.
-# DO NOT change this number unless you have obtained a bot flag! If you have a bot flag, then you have created your own
+# To be safe and avoid getting blocked, leave the api_sleep value at its default: 1.25 s.
+# The option to increase the delay is offered if the user is a "newbie", defined as having an
+# account less than four days old and with fewer than 50 edits. The newbie limit is 8 edits per minute.
+# Therefore, newbies should set the API sleep value to 8 to avoid getting blocked.
+api_sleep = 1.25
+if '--apisleep' in opts: # delay between API POSTs. Used by newbies to slow writes to within limits. 
+    api_sleep = args[opts.index('--apisleep')] # Number of seconds between API calls. Numeric only, do not include "s"
+if '-A' in opts:
+    api_sleep = args[opts.index('-A')]
+
+# DO NOT decrease this limit unless you have obtained a bot flag! If you have a bot flag, then you have created your own
 # User-Agent and are not using VanderBot any more. In that case, you must change the user_agent_header below to reflect
 # your own information. DO NOT get me in trouble by saying you are using my User-Agent if you are going to violate 
 # Wikimedia guidelines !!!
-api_sleep = 1.25 # number of seconds between API calls.
+if api_sleep < 1.25:
+    api_sleep = 1.25
+
 # See https://meta.wikimedia.org/wiki/User-Agent_policy
 user_agent_header = 'VanderBot/' + version + ' (https://github.com/HeardLibrary/linked-data/tree/master/vanderbot; mailto:steve.baskauf@vanderbilt.edu)'
 

--- a/vanderbot/vanderbot.py
+++ b/vanderbot/vanderbot.py
@@ -1,6 +1,6 @@
 # VanderBot, a script for writing CSV data to a Wikibase API.  vanderbot.py
-version = '1.7.1'
-created = '2021-04-06'
+version = '1.8'
+created = '2021-08-15'
 
 # (c) 2021 Vanderbilt University. This program is released under a GNU General Public License v3.0 http://www.gnu.org/licenses/gpl-3.0
 # Author: Steve Baskauf
@@ -93,6 +93,10 @@ created = '2021-04-06'
 # Version 1.7.1 change notes (2021-04-06):
 # - enable --version option.
 # add more complete error trapping for dates
+# -----------------------------------------
+# Version 1.8 change notes (2021-08-15):
+# - enable --version option.
+# 
 
 import json
 import requests
@@ -220,7 +224,7 @@ else:  # credential file is in a directory whose path was specified by the crede
 # Wikimedia guidelines !!!
 api_sleep = 1.25 # number of seconds between API calls.
 # See https://meta.wikimedia.org/wiki/User-Agent_policy
-user_agent_header = 'VanderBot/1.7 (https://github.com/HeardLibrary/linked-data/tree/master/vanderbot; mailto:steve.baskauf@vanderbilt.edu)'
+user_agent_header = 'VanderBot/' + version + ' (https://github.com/HeardLibrary/linked-data/tree/master/vanderbot; mailto:steve.baskauf@vanderbilt.edu)'
 
 # Set the value of the maxlag parameter to back off when the server is lagged
 # see https://www.mediawiki.org/wiki/Manual:Maxlag_parameter

--- a/vanderbot/vanderbot.py
+++ b/vanderbot/vanderbot.py
@@ -1755,6 +1755,13 @@ for table in tables:  # The script can handle multiple tables
             print('Write confirmation: ', json.dumps(responseData), file=log_object)
             print('', file=log_object)
 
+            if 'error' in responseData:
+                error_log = 'Error message from API in row ' + str(rowNumber) + ': ' + responseData['error']['info'] + '\n'
+                print('failed write due to error from API', file=log_object)
+                print('', file=log_object)
+                continue # Do not try to extract data from the response JSON. Go on with the next row and leave CSV unchanged.
+
+
             if newItem:
                 # extract the entity Q number from the response JSON
                 tableData[rowNumber][subjectWikidataIdColumnHeader] = responseData['entity']['id']
@@ -1822,7 +1829,12 @@ for table in tables:  # The script can handle multiple tables
                                 # it would have already been downloaded in the processing prior to running this script.
                                 # OK, here's the situation where it happens: the script fails or is killed after writing to the API, but before the data are written to the CSV.
                                 # In that case, the statement will be written a second time and both will show up in the JSON returned from the API
-                                dup_message = 'Warning: duplicate statement ', tableData[rowNumber][subjectWikidataIdColumnHeader], ' ', propertiesIdList[statementIndex], ' ', tableData[rowNumber][propertiesColumnList[statementIndex]]
+                                dup_message = 'Warning: duplicate statement ' + tableData[rowNumber][subjectWikidataIdColumnHeader] + ' ' + propertiesIdList[statementIndex] + ' '
+                                if propertiesEntityOrLiteral[statementIndex] == 'value':
+                                    dup_message += tableData[rowNumber][propertiesColumnList[statementIndex] + '_val']
+                                else:
+                                    dup_message += tableData[rowNumber][propertiesColumnList[statementIndex]]
+                                dup_message += '\n'
                                 print(dup_message)
                                 error_log += dup_message + '\n'
                             tableData[rowNumber][propertiesUuidColumnList[statementIndex]] = statement['id'].split('$')[1]  # just keep the UUID part after the dollar sign


### PR DESCRIPTION
Version 1.8 change notes (2021-08-17):
- enable --apisleep option to limit API write rate for newbies
- add error trapping for errors not allowed by API
- add special handling for Commons media when P18 is used